### PR TITLE
delete check of {{}}

### DIFF
--- a/language-specs/haml.lang
+++ b/language-specs/haml.lang
@@ -74,10 +74,6 @@
           <match>\.[a-zA-Z0-9\-\_]+</match>
         </context>
         
-        <context id="unclosed-brecket" style-ref="error">
-          <match>\}(?!{)</match>
-        </context>
-        
         <context id="erb-hash" class="no-spell-check">
           <start>{</start>
           <end>}</end>


### PR DESCRIPTION
The original` haml.lang `will show errors if you use` {{}} ` which you will use in angular.
Delete these lines will remove the check of the close of curly brackets.